### PR TITLE
Update to 1.21.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ modImplementation "xyz.breadloaf.imguimc:imgui-mc:${project.imguimc_version}"
 | 1.21.1     | 1.21.1-1.0.8    | [1.86.12](https://github.com/SpaiR/imgui-java/releases/tag/1.86.12) |
 | 1.21.3     | 1.21.3-1.0.9    | [1.86.12](https://github.com/SpaiR/imgui-java/releases/tag/1.86.12) |
 | 1.21.3     | 1.21.3-1.1.0    | [1.86.12](https://github.com/SpaiR/imgui-java/releases/tag/1.86.12) |
+| 1.21.4     | 1.21.4-1.1.0    | [1.86.12](https://github.com/SpaiR/imgui-java/releases/tag/1.86.12) |
 
 
 ## Features

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs=-Xmx2G
-minecraft_version=1.21.3
-minecraft_dependency=1.21.3
-loader_version=0.16.9
-fabric_version=0.110.0+1.21.3
-mod_version=1.21.3-1.1.0
+minecraft_version=1.21.4
+minecraft_dependency=1.21.4
+loader_version=0.16.13
+fabric_version=0.119.2+1.21.4
+mod_version=1.21.4-1.1.0
 maven_group=xyz.breadloaf.imguimc
 archives_base_name=imguimc
 mod_name=imgui-mc


### PR DESCRIPTION
Hi,

I have done a quick test and I was able to run it in 1.21.4 without any code changes with this gradle.properties

```
org.gradle.jvmargs=-Xmx2G
minecraft_version=1.21.4
minecraft_dependency=1.21.4
loader_version=0.16.13
fabric_version=0.119.2+1.21.4
mod_version=1.21.4-1.1.0
maven_group=xyz.breadloaf.imguimc
archives_base_name=imguimc
mod_name=imgui-mc

imguiVersion=1.86.12
```

If possible please could the mod be updated to this version on Modrinth? I would love to update my mod to 1.21.4 but this is a dependency.

Thanks!